### PR TITLE
Fix regex for API-Keys

### DIFF
--- a/TS3Bot.py
+++ b/TS3Bot.py
@@ -44,24 +44,20 @@ audit_period = int(configs.get('bot settings','audit_period')) #How long a singl
 audit_interval = int(configs.get('bot settings','audit_interval')) # how often the BOT audits all users
 client_restriction_limit= int(configs.get('bot settings','client_restriction_limit'))
 timer_msg_broadcast = int(configs.get('bot settings','broadcast_message_timer'))
+locale_setting = configs.get('bot settings','locale')
 
 # Debugging (on or off) True/False
 DEBUG = ast.literal_eval(configs.get('DEBUGGING','DEBUG'))
 
+locale = getLocale(locale_setting)
+
 #######################################
-
-# Banner that we send to all users upon initialization (not in bot_messages.py because it requires some variables from this script)
-bot_msg='''
- %s is alive once again! Type 'verifyme' in the "%s" channel to begin verification!
-''' %(bot_nickname,channel_name)
-
 
 #######################################
 ## Basic Classes
 #######################################
 
 class Bot:
-
         def __init__(self,db,ts_connection):
                 admin_data=ts_connection.whoami()
                 self.db_name=db
@@ -73,7 +69,6 @@ class Bot:
                 self.groupFind(verified_group)
                 self.getUserDatabase()
                 self.c_audit_date=datetime.date.today() # Todays Date
-
 
         #Helps find the group ID for 'verified users group'
         def groupFind(self,group_to_find):
@@ -206,7 +201,7 @@ class Bot:
             self.db_conn.commit()
 
         def broadcastMessage(self):
-            self.ts_connection.sendtextmessage( targetmode=2,target=server_id, msg=bot_msg_broadcast)
+            self.ts_connection.sendtextmessage( targetmode=2,target=server_id, msg=locale.get("bot_msg_broadcast"))
 
         def getActiveTsUserID(self,client_unique_id):
             return self.ts_connection.clientgetids(cluid=client_unique_id)[0].get('clid')
@@ -274,10 +269,10 @@ def my_event_handler(sender, event):
                         if cmd == 'verifyme':
                                 if BOT.clientNeedsVerify(rec_from_uid):
                                         TS3Auth.log("Verify Request Recieved from user '%s'. Sending PM now...\n        ...waiting for user response." %rec_from_name)
-                                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_verify)
+                                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=locale.get("bot_msg_verify"))
                                 else:
                                         TS3Auth.log("Verify Request Recieved from user '%s'. Already verified, notified user." %rec_from_name)
-                                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_alrdy_verified)
+                                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=locale.get("bot_msg_alrdy_verified"))
 
 
                 # Type 1 means it was a private message
@@ -319,24 +314,24 @@ def my_event_handler(sender, event):
                                             print ("Added user to DB with ID %s" %rec_from_uid)
 
                                             #notify user they are verified
-                                            sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_success)
+                                            sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=locale.get("bot_msg_success"))
                                         else:
                                             # client limit is set and hit
-                                            sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_limit_Hit)
+                                            sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=locale.get("bot_msg_limit_Hit"))
                                             TS3Auth.log("Received API Auth from %s, but %s has reached the client limit." %(rec_from_name,rec_from_name))
                                 
                                             
                                 else:
                                         #Auth Failed
-                                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_fail)
+                                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=locale.get("bot_msg_fail"))
                         else:
                                 TS3Auth.log("Received API Auth from %s, but %s is already verified. Notified user as such." %(rec_from_name,rec_from_name))
-                                sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_alrdy_verified)
+                                sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=locale.get("bot_msg_alrdy_verified"))
                                         
                         
 
                     else: 
-                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_rcv_default)
+                        sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=locale.get("bot_msg_rcv_default"))
                         TS3Auth.log("Received bad response from %s [msg= %s]" %(rec_from_name,raw_cmd.encode('utf-8')))
         except Exception as e:
                 TS3Auth.log('BOT Event: Something went wrong during message received from teamspeak server. Likely bad user command/message.')
@@ -408,7 +403,7 @@ while bot_loop_forever:
                     BOT.ts_connection.recv_in_thread()
 
                     #Send message to the server that the BOT is up
-                    BOT.ts_connection.sendtextmessage( targetmode=3,target=server_id, msg=bot_msg)
+                    BOT.ts_connection.sendtextmessage( targetmode=3,target=server_id, msg=locale.get("bot_msg",(bot_nickname,channel_name)))
                     TS3Auth.log("BOT is now registered to receive messages!")
 
 

--- a/TS3Bot.py
+++ b/TS3Bot.py
@@ -283,13 +283,13 @@ def my_event_handler(sender, event):
                 # Type 1 means it was a private message
                 elif rec_type == '1':
                     #reg_api_auth='\s*(\S+\s*\S+\.\d+)\s+(.*?-.*?-.*?-.*?-.*)\s*$'
-                    reg_api_auth='\s*?-.*?-.*?-.*?-.*\s*$'
+                    reg_api_auth='\s*(.*?-.*?-.*?-.*?-.*)\s*$'
 
 
                     #Command for verifying authentication
                     if re.match(reg_api_auth,raw_cmd):
                         pair=re.search(reg_api_auth,raw_cmd)
-                        uapi=pair.group(0)
+                        uapi=pair.group(1)
 
                         if BOT.clientNeedsVerify(rec_from_uid):
                                 
@@ -338,8 +338,9 @@ def my_event_handler(sender, event):
                     else: 
                         sender.sendtextmessage( targetmode=1, target=rec_from_id, msg=bot_msg_rcv_default)
                         TS3Auth.log("Received bad response from %s [msg= %s]" %(rec_from_name,raw_cmd.encode('utf-8')))
-        except:
+        except Exception as e:
                 TS3Auth.log('BOT Event: Something went wrong during message received from teamspeak server. Likely bad user command/message.')
+                TS3Auth.log(e)
 
                 
         return None

--- a/bot_messages.py
+++ b/bot_messages.py
@@ -1,95 +1,123 @@
 #######################################
 ## BOT Messages
 #######################################
+import TS3Auth
+
+class Locale(object):
+  def __init__(self, fallback = None):
+    self._fallback = fallback
+    self._values = {}
+
+  def get(self, key, args = ()):
+    '''
+    key: the string to identify the locale-string with
+    args: an optional tuple of arguments to pass to the old style formatter. If the number of arguments don't match the number of template spots in the string, no argument will be inserted at all
+    returns: either the looked-up locale-string, the loooked-up locale from the fallback Locale (if any) or the key as fallback-fallback
+    '''
+    tpl = ""
+    if key in self._values:
+      tpl = self._values[key]
+    elif self._fallback is not None:
+      tpl = self._fallback.get(key)
+    else:
+      tpl = key
+    try:
+      tpl = tpl % args
+    except TypeError:
+      TS3Auth.log("Could not insert all %d arguments into the string with key '%s' of locale %d. I will not insert any arguments at all." % (len(args), key, self.__class__.__name__))
+    return tpl
+
+  def set(self, key, value):
+    self._values[key] = value
+
+class English(Locale):
+  def __init__(self):
+      super(English, self).__init__()
+      self.set("bot_msg_example", "\n\nExample:\n\t\t7895D172-4991-9546-CB5B-78B015B0D8A72BC0E007-4FAF-48C3-9BF1-DA1OAD241266")
+      self.set("bot_msg_note", "\n\nNOTE: Guild Wars 2 API keys can be created/deleted via ArenaNet site 'account.arena.net/applications'.")
+      self.set("bot_msg_verify", "Hello there! I believe you requested verification?\n\nIf so please reply back to THIS PRIVATE MESSAGE with your API key."+self.get("bot_msg_example")+self.get("bot_msg_note"))
+      
+      # Banner that we send to all users upon initialization
+      self.set("bot_msg", "%s is alive once again! Type 'verifyme' in the '%s' channel to begin verification!")
+
+      # Broadcast message
+      self.set("bot_msg_broadcast", "Hello there! You can begin verification by typing 'verifyme' in this channel.")
+      
+      #Message sent for sucesful verification
+      self.set("bot_msg_success", "Authentication was succesful! Thank you fellow Adventurer. Have fun \(^.^)/")
+      
+      #Message sent for failed verification
+      self.set("bot_msg_fail",  "Unfortuntely your authentication failed. Ask the Teamspeak admin to review the logs.\n~ Likely a bad API key or incorrect API settings. (API Key needs access to 'account' and 'character' )"+self.get("bot_msg_note"))
+
+      #Message sent for client TS ID limit reached (trying to access Teamspeack from a second computer after having authenticated on a prior machine
+      self.set("bot_msg_limit_Hit", "The TeamSpeak Admins have set a limit to how many computers can authenticate with your Guild Wars 2 account. You are already authenticated from a different computer (or you reinstalled Teamspeak client which reset your TeamSpeak ID with this server).")
+
+      #Message sent to someone who is already verified but asks to be verified
+      self.set("bot_msg_alrdy_verified", "It looks like you are already verified! Why do you torture me sooo /cry")
+
+      #Message sent to someone who is not verified but asks to set guild tags via channel text.
+      self.set("bot_msg_sguild_nv", "I'm sorry, I can't help you set guild tags unless you are authenticated. Please verify first by replying to me with your API key."+self.get("bot_msg_example")+self.get("bot_msg_note"))
+
+      #Message sent to someone who is verified and asks to set guild tags.
+      self.set("bot_msg_sguild", "Let's get to work! First, I need your API key (we don't store your API key in the backend). Reply back with your API key:"+self.get("bot_msg_example")+self.get("bot_msg_note"))
+
+      #Message sent to someone who is not verified and asks to set guild tags via private message.
+      self.set("bot_msg_gld_needs_auth", "Where you trying to change your guild tags? If so, please be aware you have not been verified yet! Read below to verify."+self.get("bot_msg_example"))
+
+      #Base Message sent to someone who gave us the API key to pull guild tags.
+      self.set("bot_msg_gld_lis", "API Authentication succeeded. Session built. Here are your guild TAGS your can choose to assign:")
+
+      #Default message we send to Private messages that didn't match a command
+      self.set("bot_msg_rcv_default", "Hrm...So I get that your saying something but I don't understand what. Are you trying to get verified? If so please provide your API key in the format:"+self.get("bot_msg_example")+self.get("bot_msg_note"))
+
+class German(Locale):
+  def __init__(self):
+    super(German, self).__init__(English())
+    self.set("bot_msg_example", "\n\nBeispiel:\n\t\t7895D172-4991-9546-CB5B-78B015B0D8A72BC0E007-4FAF-48C3-9BF1-DA1OAD241266")
+    self.set("bot_msg_note", "\n\nINFO: Guild Wars 2 API keys können über die ArenaNet-Seite 'account.arena.net/applications' erstellt/gelöscht werden.")
+    self.set("bot_msg_verify", "Hallöchen! Möchtest du dich registrieren?\n\nFalls ja, antworte bitte per PRIVATER NACHRICHT mit deinem API-Key."+self.get("bot_msg_example")+self.get("bot_msg_note"))
+
+    # Banner that we send to all users upon initialization
+    self.set("bot_msg", "%s ist wieder da! Schreibe 'verifyme' in den '%s' Kanal um die Freischaltung zu beginnen!")
+
+    # Broadcast message
+    self.set("bot_msg_broadcast", "Hallöchen! Du kannst die Freischaltung beginnen, indem du 'verifyme' in diesem Channel schreibst.")
+    
+    #Message sent for sucesful verification
+    self.set("bot_msg_success", "Freischaltung erfolgreich! Danke dir, Abenteurer. Viel Spaß \(^.^)/")
+    
+    #Message sent for failed verification
+    self.set("bot_msg_fail",  "Leider hat die Freischaltung nicht funktioniert. Bitte einen Teamspeak Administrator die Logs zu prüfen.\n~ Wahrscheinlich ein ungültiger API-Schlüssel oder falsche API-Einstellungen. (Der API-Schlüssel braucht die Berechtigungen 'account' und 'character')"+self.get("bot_msg_note"))
+
+    #Message sent for client TS ID limit reached (trying to access Teamspeack from a second computer after having authenticated on a prior machine
+    self.set("bot_msg_limit_Hit", "Die Teamspeak Admins haben ein Limit gesetzt, auf wie vielen Geräten du dich mit deinem Guild Wars 2 Account freischalten kannst. Du bist bereits von einem anderen Gerät aus registriert (oder du hat Teamspeak neu installiert, wodurch deine Teamspeak ID für diesen Servert zurückgesetzt wurde).")
+
+    #Message sent to someone who is already verified but asks to be verified
+    self.set("bot_msg_alrdy_verified", "Es scheint, als seist du bereits freigeschaltet! Wieso quälst du mich sooo /cry")
+
+    #Message sent to someone who is not verified but asks to set guild tags via channel text.
+    self.set("bot_msg_sguild_nv", "Tut mir leid, ich kann dir erst dabei helfen, ein Gildentag zu setzen, sobald du freigeschaltet bist. Bitte schalte dich frei, indem du mir mit einem API-Schlüssel antwortest."+self.get("bot_msg_example")+self.get("bot_msg_note"))
+
+    #Message sent to someone who is verified and asks to set guild tags.
+    self.set("bot_msg_sguild", "Lass uns anfangen! Zuerst brauche ich deinen API-Schlüssel (wir speichern keine Schlüssel). Antworte mir mit deinem API-Schlüssel:"+self.get("bot_msg_example")+self.get("bot_msg_note"))
+
+    #Message sent to someone who is not verified and asks to set guild tags via private message.
+    self.set("bot_msg_gld_needs_auth", "Wolltest du dein Gildentag ändern? Falls ja, beachte, dass du noch nicht freigeschaltet bist! Lies weiter, um dich freizuschalten."+self.get("bot_msg_example"))
+
+    #Base Message sent to someone who gave us the API key to pull guild tags.
+    self.set("bot_msg_gld_lis", "API-Freischaltung erfolgreich. Sitzung erstellt. Hier sind die Gildentags, aus denen du wählen kannst:")
+
+    #Default message we send to Private messages that didn't match a command
+    self.set("bot_msg_rcv_default", "Hm... ich merke, dass du etwas von mir willst, aber ich verstehe dich nicht. Möchtest du dich freischalten? Falls ja, bitte gib deinen API-Schlüssel in folgendem Format an:"+self.get("bot_msg_example")+self.get("bot_msg_note"))
 
 
-# Message in response to someone asking us to verify them
-bot_msg_verify='''
- Hello there! I believe you requested verification?
+def getLocale(locale):
+  locale = locale or "" # make sure upper() doesn't fail on empty arguments
+  locale = locale.upper()
 
- If so please reply back to THIS PRIVATE MESSAGE with your API key.
-
- Ex.
-      7895D172-4991-9546-CB5B-78B015B0D8A72BC0E007-4FAF-48C3-9BF1-DA1OAD241266
-
-   NOTE: Guild Wars 2 API keys can be created/deleted via ArenaNet site "https://account.arena.net/login?redirect_uri=%2Fapplications".
-
-'''
-
-# Broadcast message
-bot_msg_broadcast='''
- Hello there! You can begin verification by typing 'verifyme' in this channel.
-'''
-
-#Message sent for sucesful verification
-bot_msg_success='''
-  Authentication was succesful! Thank you fellow Adventurer. Have fun \(^.^)/
-''' 
-
-#Message sent for failed verification
-bot_msg_fail='''
-  Unfortantely your authentication failed. Ask the Teamspeak admin to review the logs.
-     ~ Likely a bad API key or incorrect API settings. ( API Key needs access to 'account' and 'character' )
-
-NOTE: Guild Wars 2 API keys permission can be viewed via ArenaNet site "https://account.arena.net/login?redirect_uri=%2Fapplications".
-'''
-
-#Message sent for client TS ID limit reached (trying to access Teamspeack from a second computer after having authenticated on a prior machine
-bot_msg_limit_Hit='''
-   The TeamSpeak Admins have set a limit to how many computers can authenticate with your Guild Wars 2 account. You are already authenticated
-   from a different computer (or you reinstalled Teamspeak client which reset your TeamSpeak ID with this server).
-
-'''
-
-#Message sent to someone who is already verified but asks to be verified
-bot_msg_alrdy_verified='''
-  It looks like you are already verified! Why do you torture me sooo /cry
-'''
-
-#Message sent to someone who is not verified but asks to set guild tags via channel text.
-bot_msg_sguild_nv='''
-  I'm sorry, I can't help you set guild tags unless you are authenticated. Please verify first by replying to me with your API key.
-
-   Ex.
-       7895D172-4991-9546-CB5B-78B015B0D8A72BC0E007-4FAF-48C3-9BF1-DA1OAD241266
-
-'''
-
-#Message sent to someone who is verified and asks to set guild tags.
-bot_msg_sguild='''
-        Let's get to work! First, I need your API key (we don't store your API key in the backend). Reply back with your API key:
-
-           Ex.
-               7895D172-4991-9546-CB5B-78B015B0D8A72BC0E007-4FAF-48C3-9BF1-DA1OAD241266
-
-'''
-
-#Message sent to someone who is not verified and asks to set guild tags via private message.
-bot_msg_gld_needs_auth='''
-
-        Where you trying to change your guild tags? If so, please be aware you have not been verified yet! Read below to verify:
-
-        Otherwise, It appears you were attempting to verify but only sent me your API key. If veryfing remember to reply with your Account Name and API key.
-
-   Ex.
-      7895D172-4991-9546-CB5B-78B015B0D8A72BC0E007-4FAF-48C3-9BF1-DA1OAD241266
-'''
-
-#Base Message sent to someone who gave us the API key to pull guild tags.
-bot_msg_gld_list='''
-  API Authentication succedded. Session built. Here are your guild TAGS your can choose to assign:
-'''
-
-#Default message we send to Private messages that didn't match a command
-bot_msg_rcv_default='''
-  Hrm...So I get that your saying something but I don't understand what. Are you trying to get verified? If so please provide your
-    account name with API key in the format:
-
-    Example:
-
-      7895D172-4991-9546-CB5B-78B015B0D8A72BC0E007-4FAF-48C3-9BF1-DA1OAD241266
-
-'''
-
-
-#######################################
+  if locale == "DE":
+    return German()
+  elif locale == "EN":
+    return English()
+  else:
+    return English() # catchall


### PR DESCRIPTION
The former version was lacking the leading group
of characters.